### PR TITLE
Circuit Breaker for failed http client request

### DIFF
--- a/taglib-core/src/main/java/com/reevoo/client/Cache.java
+++ b/taglib-core/src/main/java/com/reevoo/client/Cache.java
@@ -10,7 +10,6 @@ public class Cache {
     private static final com.google.common.cache.Cache<String, ReevooMarkRecord> backingCache =
       CacheBuilder.newBuilder()
              .maximumSize(10000)
-             .expireAfterWrite(4 * 60 * 60, TimeUnit.SECONDS)
              .softValues()
              .build();
 

--- a/taglib-core/src/main/java/com/reevoo/client/ReevooMarkRecord.java
+++ b/taglib-core/src/main/java/com/reevoo/client/ReevooMarkRecord.java
@@ -4,26 +4,24 @@ import java.util.Calendar;
 import java.util.Date;
 
 public final class ReevooMarkRecord {
-    private final Date expiration_time;
-    public final String value;
-    public final int status;
-    public final int review_count;
 
-    public ReevooMarkRecord(String value, int time_out, int status, int review_count) {
+    private Date expirationTime;
+    private final String value;
+    private final int status;
+    private final int reviewCount;
+    private int consecutiveFailedAttempts = 0;
+
+    private ReevooMarkRecord(String value, int timeout, int status, int reviewCount) {
         Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.SECOND, time_out);
-        expiration_time = cal.getTime();
+        cal.add(Calendar.SECOND, timeout);
+        expirationTime = cal.getTime();
         this.status = status;
         this.value = value;
-        this.review_count = review_count;
-    }
-
-    public ReevooMarkRecord(ReevooMarkRecord old, int time_out) {
-        this(old.value, time_out, old.status, old.review_count);
+        this.reviewCount = reviewCount;
     }
 
     public boolean hasExpired() {
-        return new Date().after(expiration_time);
+        return new Date().after(expirationTime);
     }
 
     public boolean fresh() {
@@ -31,6 +29,62 @@ public final class ReevooMarkRecord {
     }
 
     public Date getExpirationTime() {
-        return expiration_time;
+        return expirationTime;
     }
+
+    public void setExpirationTime(Date expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public int getStatus() {
+        return this.status;
+    }
+
+    public int getReviewCount() {
+        return this.reviewCount;
+    }
+
+    public int getConsecutiveFailedAttempts() {
+        return this.consecutiveFailedAttempts;
+    }
+
+    /**
+     * Creates a new ReevooMarkRecord initialized with the provided value.
+     * @param value
+     * @param timeout
+     * @param status
+     * @param reviewCount
+     * @return The new ReevooMarkRecord instance.
+     */
+    public static ReevooMarkRecord createRecord(String value, int timeout, int status, int reviewCount) {
+        return new ReevooMarkRecord(value, timeout, status, reviewCount);
+    }
+
+    /**
+     * Creates a new ReevooMarkRecord as a clone of the provided one and overriding the provided values
+     * @param old
+     * @param timeout
+     * @param status
+     * @return The new ReevooMarkRecord instance.
+     */
+    public static ReevooMarkRecord createRecord(ReevooMarkRecord old, int timeout, int status) {
+        ReevooMarkRecord newRecord;
+        if (old != null) {
+            newRecord = new ReevooMarkRecord(old.value, timeout, status, old.reviewCount);
+        } else {
+            newRecord = new ReevooMarkRecord(null, timeout, status, 0);
+        }
+        if (status >= 400) {
+            newRecord.consecutiveFailedAttempts = old != null ? old.consecutiveFailedAttempts + 1 : 1;
+        } else {
+            newRecord.consecutiveFailedAttempts = 0;
+        }
+        return newRecord;
+    }
+
+
 }

--- a/taglib-core/src/test/java/com/reevoo/client/ReevooMarkRecordTest.java
+++ b/taglib-core/src/test/java/com/reevoo/client/ReevooMarkRecordTest.java
@@ -13,33 +13,33 @@ public class ReevooMarkRecordTest {
 
     @Test
     public void testCreation() {
-        ReevooMarkRecord rmr = new ReevooMarkRecord("test_record", 1000, 200, 100);
-        assertEquals(rmr.value, "test_record");
-        assertEquals(rmr.status, 200);
-        assertEquals(rmr.review_count, 100);
+        ReevooMarkRecord rmr = ReevooMarkRecord.createRecord("test_record", 1000, 200, 100);
+        assertEquals(rmr.getValue(), "test_record");
+        assertEquals(rmr.getStatus(), 200);
+        assertEquals(rmr.getReviewCount(), 100);
     }
 
     @Test
     public void testExpirationWithPositiveTimeout() {
-        ReevooMarkRecord rmr = new ReevooMarkRecord("test_record", 1000, 200, 100);
-        assertEquals(rmr.value, "test_record");
+        ReevooMarkRecord rmr = ReevooMarkRecord.createRecord("test_record", 1000, 200, 100);
+        assertEquals(rmr.getValue(), "test_record");
         assertTrue(rmr.fresh());
     }
 
     @Test
     public void testExpirationWithNegativeTimeout() {
-        ReevooMarkRecord rmr = new ReevooMarkRecord("test_record", -100, 200, 100);
-        assertEquals(rmr.value, "test_record");
+        ReevooMarkRecord rmr = ReevooMarkRecord.createRecord("test_record", -100, 200, 100);
+        assertEquals(rmr.getValue(), "test_record");
         assertTrue(rmr.hasExpired());
     }
 
     @Test
     public void testCanCreateUsingExistingObject() {
-        ReevooMarkRecord rmr_existing = new ReevooMarkRecord("test_record", -100, 200, 100);
-        ReevooMarkRecord rmr_new = new ReevooMarkRecord(rmr_existing, 100);
-        assertEquals(rmr_new.value, "test_record");
-        assertEquals(rmr_new.status, 200);
-        assertEquals(rmr_new.review_count, 100);
+        ReevooMarkRecord rmr_existing = ReevooMarkRecord.createRecord("test_record", -100, 200, 100);
+        ReevooMarkRecord rmr_new = ReevooMarkRecord.createRecord(rmr_existing, 100, 200);
+        assertEquals(rmr_new.getValue(), "test_record");
+        assertEquals(rmr_new.getStatus(), 200);
+        assertEquals(rmr_new.getReviewCount(), 100);
         assertTrue(rmr_new.fresh());
 
     }

--- a/taglib/src/main/java/com/reevoo/taglib/AbstractReevooMarkClientTag.java
+++ b/taglib/src/main/java/com/reevoo/taglib/AbstractReevooMarkClientTag.java
@@ -31,11 +31,7 @@ public abstract class AbstractReevooMarkClientTag extends AbstractReevooTag {
     private HttpServletRequest request;
 
     public AbstractReevooMarkClientTag() {
-        this.client = new ReevooMarkClient(
-            Integer.valueOf(TaglibConfig.getProperty("http.timeout")),
-            TaglibConfig.getProperty("http.proxyHost"),
-            TaglibConfig.getProperty("http.proxyPort")
-        );
+        this.client = new ReevooMarkClient(TaglibConfig.getProperties());
     }
 
     /**

--- a/taglib/src/main/java/com/reevoo/utils/TaglibConfig.java
+++ b/taglib/src/main/java/com/reevoo/utils/TaglibConfig.java
@@ -78,6 +78,10 @@ public class TaglibConfig {
         return value;
     }
 
+    public static Properties getProperties() {
+        return properties;
+    }
+
     public static void setProperty(String name, String value) {
         properties.setProperty(name, value);
     }

--- a/taglib/src/main/resources/taglibConfig.properties
+++ b/taglib/src/main/resources/taglibConfig.properties
@@ -8,4 +8,11 @@ http.timeout=5000
 http.proxyHost=
 http.proxyPort=
 
+# failed requests to get embedded content will wait 60 seconds in between retries.
+http.failed_request.cache_time.in_seconds=60
 
+# 5 consecutive failed attempts to get embedded content will trigger the circuit-breaker (a longer wait until we try again).
+http.circuit_breaker.number_of_retries=5
+
+# Time to wait before attempting to get the embedded content once the circuit breaker kicks in.
+http.circuit_breaker.wait_time.in_seconds=300


### PR DESCRIPTION
If for whatever reason (amazon aws goes down) our servers have trouble, the client can detect it and serve cached versions of the embedded reviews, and dynamically adjust the time between retries to get a fresh version.