### PR TITLE
Forced https in all the urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,13 +407,13 @@ not provided by any of the previous tags. The tag name is "mark" and you can use
 Make sure to replace `<SKU>` and `<TRKREF>` with the appropriate values:
 
 ```JSP
-  <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews.html" />
+  <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews.html" />
 ```
 
 It is also possible to specify locale and the number of reviews you'd like in the baseURI:
 
 ```JSP
-  <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="http://mark.reevoo.com/reevoomark/fr-FR/10/embeddable_reviews.html" />
+  <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="https://mark.reevoo.com/reevoomark/fr-FR/10/embeddable_reviews.html" />
 ```
 
 ### Price Offers Widget
@@ -421,7 +421,7 @@ It is also possible to specify locale and the number of reviews you'd like in th
 To render "price offers" you can use the tag below. Please provide the sku and trkref attribute.
 
 ```JSP
- <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="http://mark.reevoo.com/widgets/offers" />
+ <reevoo:mark sku="<SKU>" trkref="<TRKREF>" baseURI="https://mark.reevoo.com/widgets/offers" />
 ```
 
 ## Tracking

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace "test" do
     system("mvn -q test")
   end
   task :verbose do
-    system("mvn test") 
+    system("mvn test")
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace "test" do
     system("mvn -q test")
   end
   task :verbose do
-    system("mvn test")
+    system("mvn test") 
   end
 end
 

--- a/taglib-core/src/test/java/com/reevoo/client/HttpClientFactoryTest.java
+++ b/taglib-core/src/test/java/com/reevoo/client/HttpClientFactoryTest.java
@@ -25,31 +25,31 @@ public class HttpClientFactoryTest {
 
     @Test
     public void testWhenProxyIsSetThroughEnvironmentVariables() {
-        System.setProperty("http.proxyHost", "http://example-proxy.com");
+        System.setProperty("http.proxyHost", "https://example-proxy.com");
         System.setProperty("http.proxyPort", "8080");
 
         HttpClient client = HttpClientFactory.build(10, null, null);
 
-        assertEquals(client.getHostConfiguration().getProxyHost(), "http://example-proxy.com");
+        assertEquals(client.getHostConfiguration().getProxyHost(), "https://example-proxy.com");
         assertEquals(client.getHostConfiguration().getProxyPort(), 8080);
     }
 
     @Test
     public void testWhenProxyIsSetThroughMethodParams() {
-        HttpClient client = HttpClientFactory.build(10, "http://example-proxy.com", "9999");
+        HttpClient client = HttpClientFactory.build(10, "https://example-proxy.com", "9999");
 
-        assertEquals(client.getHostConfiguration().getProxyHost(), "http://example-proxy.com");
+        assertEquals(client.getHostConfiguration().getProxyHost(), "https://example-proxy.com");
         assertEquals(client.getHostConfiguration().getProxyPort(), 9999);
     }
 
     @Test
     public void testProxySettingThroughMethodTakePriorityOnProxySettingsThroughEnvironmentVariables() {
-        System.setProperty("http.proxyHost", "http://example-proxy.com");
+        System.setProperty("http.proxyHost", "https://example-proxy.com");
         System.setProperty("http.proxyPort", "8080");
 
-        HttpClient client = HttpClientFactory.build(10, "http://another-proxy.com", "7777");
+        HttpClient client = HttpClientFactory.build(10, "https://another-proxy.com", "7777");
 
-        assertEquals(client.getHostConfiguration().getProxyHost(), "http://another-proxy.com");
+        assertEquals(client.getHostConfiguration().getProxyHost(), "https://another-proxy.com");
         assertEquals(client.getHostConfiguration().getProxyPort(), 7777);
     }
 

--- a/taglib-core/src/test/java/com/reevoo/client/ReevooMarkClientTest.java
+++ b/taglib-core/src/test/java/com/reevoo/client/ReevooMarkClientTest.java
@@ -40,19 +40,19 @@ public class ReevooMarkClientTest {
     private HttpClient h;
 
     private void setFreshCache(int status) {
-        Cache.put("http://www.example.org/reevoomark", ReevooMarkRecord.createRecord("cached_response", 60, status, 100));
+        Cache.put("https://www.example.org/reevoomark", ReevooMarkRecord.createRecord("cached_response", 60, status, 100));
     }
 
     private void setStaleCache(int status) {
-        Cache.put("http://www.example.org/reevoomark", ReevooMarkRecord.createRecord("cached_response", -60, status, 100));
+        Cache.put("https://www.example.org/reevoomark", ReevooMarkRecord.createRecord("cached_response", -60, status, 100));
     }
 
     private String getCache() {
-        return Cache.get("http://www.example.org/reevoomark").getValue();
+        return Cache.get("https://www.example.org/reevoomark").getValue();
     }
 
     private boolean failedAttempts(int number) {
-        return Cache.get("http://www.example.org/reevoomark").getConsecutiveFailedAttempts() == 1;
+        return Cache.get("https://www.example.org/reevoomark").getConsecutiveFailedAttempts() == 1;
     }
 
     private void expireCacheEntry(ReevooMarkRecord cacheEntry) {
@@ -70,7 +70,7 @@ public class ReevooMarkClientTest {
     @Before
     public void setUp() throws Exception {
         m = mock(GetMethod.class);
-        when(m.getURI()).thenReturn(new URI("http://www.example.org/reevoomark"));
+        when(m.getURI()).thenReturn(new URI("https://www.example.org/reevoomark"));
         when(m.getResponseBodyAsStream()).thenReturn(new ByteArrayInputStream("fresh_response".getBytes()));
         when(m.getResponseHeader("X-Reevoo-ReviewCount")).thenReturn(new Header("X-Reevoo-ReviewCount", "8"));
         h = mock(HttpClient.class);
@@ -189,7 +189,7 @@ public class ReevooMarkClientTest {
         Date expected_time = cal.getTime();
 
         String data = c.obtainReevooMarkData(m);
-        Date cache_expires = Cache.get("http://www.example.org/reevoomark").getExpirationTime();
+        Date cache_expires = Cache.get("https://www.example.org/reevoomark").getExpirationTime();
 
         assertEquals((double) expected_time.getTime(), (double) cache_expires.getTime(), 1000);
     }
@@ -244,7 +244,7 @@ public class ReevooMarkClientTest {
     public void testFailedRequestAreCachedByConfiguredNumberOfSeconds() throws IOException {
         when(m.getStatusCode()).thenReturn(500);
         c.obtainReevooMarkData(m);
-        checkExpiresInSeconds(60, Cache.get("http://www.example.org/reevoomark"));
+        checkExpiresInSeconds(60, Cache.get("https://www.example.org/reevoomark"));
     }
 
     @Test
@@ -252,9 +252,9 @@ public class ReevooMarkClientTest {
         when(m.getStatusCode()).thenReturn(404);
         for (int i = 0; i < 4; i++) {
             c.obtainReevooMarkData(m);
-            expireCacheEntry(Cache.get("http://www.example.org/reevoomark"));
+            expireCacheEntry(Cache.get("https://www.example.org/reevoomark"));
         }
-        assertEquals(4, Cache.get("http://www.example.org/reevoomark").getConsecutiveFailedAttempts());
+        assertEquals(4, Cache.get("https://www.example.org/reevoomark").getConsecutiveFailedAttempts());
     }
 
     @Test
@@ -262,35 +262,35 @@ public class ReevooMarkClientTest {
         when(m.getStatusCode()).thenReturn(404);
         for (int i = 0; i <= 5; i++) {
             c.obtainReevooMarkData(m);
-            expireCacheEntry(Cache.get("http://www.example.org/reevoomark"));
+            expireCacheEntry(Cache.get("https://www.example.org/reevoomark"));
         }
         c.obtainReevooMarkData(m);
-        checkExpiresInSeconds(300, Cache.get("http://www.example.org/reevoomark"));
+        checkExpiresInSeconds(300, Cache.get("https://www.example.org/reevoomark"));
     }
 
     @Test
     public void testSuccessfulRequestResetsConsecutiveFailedRequestsCounter() throws IOException {
         when(m.getStatusCode()).thenReturn(404);
         c.obtainReevooMarkData(m);
-        expireCacheEntry(Cache.get("http://www.example.org/reevoomark"));
-        assertEquals(Cache.get("http://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 1);
+        expireCacheEntry(Cache.get("https://www.example.org/reevoomark"));
+        assertEquals(Cache.get("https://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 1);
 
         when(m.getStatusCode()).thenReturn(200);
         c.obtainReevooMarkData(m);
-        assertEquals(Cache.get("http://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 0);
+        assertEquals(Cache.get("https://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 0);
     }
 
     @Test
     public void testFailedRequestWillReturnLastSuccessfulCachedRequestContent() throws IOException {
         ReevooMarkRecord cachedContent = ReevooMarkRecord.createRecord("valid request content", -100, 200, 60);
-        Cache.put("http://www.example.org/reevoomark", cachedContent);
+        Cache.put("https://www.example.org/reevoomark", cachedContent);
 
         when(m.getStatusCode()).thenReturn(404);
         c.obtainReevooMarkData(m);
 
-        checkExpiresInSeconds(60, Cache.get("http://www.example.org/reevoomark"));
-        assertEquals(Cache.get("http://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 1);
-        assertEquals(Cache.get("http://www.example.org/reevoomark").getValue(), "valid request content");
+        checkExpiresInSeconds(60, Cache.get("https://www.example.org/reevoomark"));
+        assertEquals(Cache.get("https://www.example.org/reevoomark").getConsecutiveFailedAttempts(), 1);
+        assertEquals(Cache.get("https://www.example.org/reevoomark").getValue(), "valid request content");
     }
 
 }

--- a/taglib-inttest/src/main/webapp/test.jsp
+++ b/taglib-inttest/src/main/webapp/test.jsp
@@ -11,19 +11,19 @@
 <h1>Test page</h1>
 
 <h2>Valid:</h2>
-<reevoo:mark sku="10" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews"/>
+<reevoo:mark sku="10" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews"/>
 
 <h2>Valid(slim):</h2>
-<reevoo:mark sku="10" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews/slim.html"/>
+<reevoo:mark sku="10" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews/slim.html"/>
 
 <h2>Valid(AAO):</h2>
-<reevoo:mark sku="167823" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_conversations"/>
+<reevoo:mark sku="167823" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_conversations"/>
 
 <h2>404:</h2>
-<reevoo:mark sku="no-a-real-sku" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews.html"/>
+<reevoo:mark sku="no-a-real-sku" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews.html"/>
 
 <h2>Connect Failure:</h2>
-<reevoo:mark sku="10" trkref="REV" baseURI="http://mark.reevoo.com:1/reevoomark/embeddable_reviews.html"/>
+<reevoo:mark sku="10" trkref="REV" baseURI="https://mark.reevoo.com:1/reevoomark/embeddable_reviews.html"/>
 <reevoo:javascriptAssets trkref="REV"/>
 
 <h2>ReevooMark Badge with default trkref</h2>

--- a/taglib-inttest/src/main/webapp/test_alternative.jsp
+++ b/taglib-inttest/src/main/webapp/test_alternative.jsp
@@ -11,27 +11,27 @@
 <h1>Test page</h1>
 
 <h2>Valid:</h2>
-<reevoo:mark sku="10" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews">
+<reevoo:mark sku="10" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews">
     <p>You should never see this</p>
 </reevoo:mark>
 
 <h2>No reviews:</h2>
-<reevoo:mark sku="22" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews">
+<reevoo:mark sku="22" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews">
     <p>You should always see this because there are no reviews.</p>
 </reevoo:mark>
 
 <h2>404:</h2>
-<reevoo:mark sku="no-a-real-sku" trkref="REV" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews">
+<reevoo:mark sku="no-a-real-sku" trkref="REV" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews">
     <p>You should always see this, because there are no reviews.</p>
 </reevoo:mark>
 
 <h2>Connect Failure:</h2>
-<reevoo:mark sku="10" trkref="REV" baseURI="http://mark.reevoo-bo.com/reevoomark/embeddable_reviews">
+<reevoo:mark sku="10" trkref="REV" baseURI="https://mark.reevoo-bo.com/reevoomark/embeddable_reviews">
     <p>You should always see this, because this mark is pointing to a non-existent server.</p>
 </reevoo:mark>
 
 <h2>Retailer Reviews:</h2>
-<reevoo:mark trkref="JSP" baseURI="http://mark.reevoo.com/reevoomark/embeddable_reviews">
+<reevoo:mark trkref="JSP" baseURI="https://mark.reevoo.com/reevoomark/embeddable_reviews">
     <p>You should never see this.</p>
 </reevoo:mark>
 

--- a/taglib/src/main/java/com/reevoo/taglib/ReevooTaglib.java
+++ b/taglib/src/main/java/com/reevoo/taglib/ReevooTaglib.java
@@ -9,7 +9,7 @@ package com.reevoo.taglib;
  */
 public class ReevooTaglib extends AbstractReevooMarkClientTag {
 
-    private String baseURI = "http://mark.reevoo.com/reevoomark/first_two_reviews.html";
+    private String baseURI = "https://mark.reevoo.com/reevoomark/first_two_reviews.html";
 
     @Override
     protected String getContent() {

--- a/taglib/src/main/resources/multitrkrefMarkloader.script
+++ b/taglib/src/main/resources/multitrkrefMarkloader.script
@@ -2,7 +2,7 @@
     (function () {
         var script = document.createElement('script');
         script.type = 'text/javascript';
-        script.src = '//cdn.mark.reevoo.com/assets/reevoo_mark.js';
+        script.src = 'https://cdn.mark.reevoo.com/assets/reevoo_mark.js';
         var s = document.getElementById('reevoomark-loader');
         s.parentNode.insertBefore(script, s);
     })();

--- a/taglib/src/main/resources/singletrkrefMarkloader.script
+++ b/taglib/src/main/resources/singletrkrefMarkloader.script
@@ -2,7 +2,7 @@
     (function () {
         var script = document.createElement('script');
         script.type = 'text/javascript';
-        script.src = '//cdn.mark.reevoo.com/assets/reevoo_mark.js';
+        script.src = 'https://cdn.mark.reevoo.com/assets/reevoo_mark.js';
         var s = document.getElementById('reevoomark-loader');
         s.parentNode.insertBefore(script, s);
     })();

--- a/taglib/src/main/resources/taglibConfig.properties
+++ b/taglib/src/main/resources/taglibConfig.properties
@@ -1,9 +1,9 @@
 default.trkref=REV
-reevoo.badges.base.url=//mark.reevoo.com
-conversations.url=http://mark.reevoo.com/reevoomark/embeddable_conversations
-reevoo.css.url=//mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css
-product.reviews.url=http://mark.reevoo.com/reevoomark/embeddable_reviews
-customer.experience.reviews.url=http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews
+reevoo.badges.base.url=https://mark.reevoo.com
+conversations.url=https://mark.reevoo.com/reevoomark/embeddable_conversations
+reevoo.css.url=https://mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css
+product.reviews.url=https://mark.reevoo.com/reevoomark/embeddable_reviews
+customer.experience.reviews.url=https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews
 http.timeout=5000
 http.proxyHost=
 http.proxyPort=

--- a/taglib/src/test/java/com.reevoo.taglib/ReevooConversationsTest.java
+++ b/taglib/src/test/java/com.reevoo.taglib/ReevooConversationsTest.java
@@ -40,7 +40,7 @@ public class ReevooConversationsTest extends BasicTagTestCaseAdapter{
         queryStringParams.put("reviews", null);
         queryStringParams.put("conversations", "3");
         verify(markClient).obtainReevooMarkData(
-            "http://mark.reevoo.com/reevoomark/embeddable_conversations",
+            "https://mark.reevoo.com/reevoomark/embeddable_conversations",
             queryStringParams);
     }
 
@@ -69,7 +69,7 @@ public class ReevooConversationsTest extends BasicTagTestCaseAdapter{
         queryStringParams.put("trkref", "REV");
         queryStringParams.put("reviews", null);
         queryStringParams.put("conversations",null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_conversations", queryStringParams);
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_conversations", queryStringParams);
     }
 
 }

--- a/taglib/src/test/java/com.reevoo.taglib/ReevooCssAssetsTest.java
+++ b/taglib/src/test/java/com.reevoo.taglib/ReevooCssAssetsTest.java
@@ -17,6 +17,6 @@ public class ReevooCssAssetsTest extends BasicTagTestCaseAdapter {
     @Test
     public void testTheCssLinkIsLoadedCorrectly() {
         processTagLifecycle();
-        verifyOutput("<link rel=\"stylesheet\" href=\"//mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css\" type=\"text/css\" />");
+        verifyOutput("<link rel=\"stylesheet\" href=\"https://mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css\" type=\"text/css\" />");
     }
 }

--- a/taglib/src/test/java/com.reevoo.taglib/ReevooCustomerExperienceReviewsTest.java
+++ b/taglib/src/test/java/com.reevoo.taglib/ReevooCustomerExperienceReviewsTest.java
@@ -33,7 +33,7 @@ public class ReevooCustomerExperienceReviewsTest extends BasicTagTestCaseAdapter
         Map<String, String> queryStringParams = new LinkedHashMap<String,String>();
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
     }
 
     @Test
@@ -43,7 +43,7 @@ public class ReevooCustomerExperienceReviewsTest extends BasicTagTestCaseAdapter
         Map<String, String> queryStringParams = new LinkedHashMap<String,String>();
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("reviews","10");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
     }
 
     @Test
@@ -54,7 +54,7 @@ public class ReevooCustomerExperienceReviewsTest extends BasicTagTestCaseAdapter
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("locale","en-GB");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
     }
 
     @Test
@@ -81,7 +81,7 @@ public class ReevooCustomerExperienceReviewsTest extends BasicTagTestCaseAdapter
         Map<String, String> queryStringParams = new LinkedHashMap<String,String>();
         queryStringParams.put("trkref", "REV");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
     }
 
     @Test
@@ -97,13 +97,13 @@ public class ReevooCustomerExperienceReviewsTest extends BasicTagTestCaseAdapter
         queryStringParams.put("page", null);
         queryStringParams.put("per_page", "5");
         queryStringParams.put("sort_by", "seo_boost");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
 
         // when paginated and numberOfReviews missing we set the per_page param to default
         cxTag.setNumberOfReviews(null);
         processTagLifecycle();
         queryStringParams.put("per_page", "default");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews", queryStringParams, "");
     }
 
 

--- a/taglib/src/test/java/com.reevoo.taglib/ReevooProductReviewsTest.java
+++ b/taglib/src/test/java/com.reevoo.taglib/ReevooProductReviewsTest.java
@@ -35,7 +35,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("sku", "12345");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -47,7 +47,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("sku", "12345");
         queryStringParams.put("locale", "fr-FR");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -58,7 +58,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("sku", "12345");
         queryStringParams.put("reviews", "10");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("sku", "12345");
         queryStringParams.put("locale","fr-FR");
         queryStringParams.put("reviews","10");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -98,7 +98,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         Map<String, String> queryStringParams = new LinkedHashMap<String,String>();
         queryStringParams.put("trkref", "REV");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -118,13 +118,13 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("page", null);
         queryStringParams.put("per_page", "5");
         queryStringParams.put("sort_by", "seo_boost");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
 
         // when paginated and numberOfReviews missing we set the per_page param to default
         productReviewsTag.setNumberOfReviews(null);
         processTagLifecycle();
         queryStringParams.put("per_page", "default");
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ReevooProductReviewsTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("fuel_type", "PETROL");
         queryStringParams.put("locale", "en-GB");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/reevoomark/embeddable_reviews", queryStringParams, "");
     }
 
 

--- a/taglib/src/test/java/com.reevoo.taglib/ReevooTaglibTest.java
+++ b/taglib/src/test/java/com.reevoo.taglib/ReevooTaglibTest.java
@@ -24,7 +24,7 @@ public class ReevooTaglibTest extends BasicTagTestCaseAdapter {
         super.setUp();
         reevooTag.setDynamicAttribute("", "sku", "ABC123");
         reevooTag.setTrkref("FOO");
-        reevooTag.setBaseURI("http://mark.reevoo.com/endpoint");
+        reevooTag.setBaseURI("https://mark.reevoo.com/endpoint");
         reevooTag.setClient(markClient);
         setTag(reevooTag);
     }
@@ -36,7 +36,7 @@ public class ReevooTaglibTest extends BasicTagTestCaseAdapter {
         queryStringParams.put("trkref", "FOO");
         queryStringParams.put("sku", "ABC123");
         queryStringParams.put("reviews", null);
-        verify(markClient).obtainReevooMarkData("http://mark.reevoo.com/endpoint", queryStringParams);
+        verify(markClient).obtainReevooMarkData("https://mark.reevoo.com/endpoint", queryStringParams);
     }
 
     @Test

--- a/taglib/src/test/java/com/reevoo/utils/TaglibConfigTest.java
+++ b/taglib/src/test/java/com/reevoo/utils/TaglibConfigTest.java
@@ -18,7 +18,7 @@ public class TaglibConfigTest {
 
     @Test
     public void ifTheCustomerProvidesTheirOwnPropertiesFileWeGivePreferenceToTheCustomerValues() {
-        Assert.assertEquals(TaglibConfig.getProperty("reevoo.badges.base.url"), "//test.reevoo.com");
+        Assert.assertEquals(TaglibConfig.getProperty("reevoo.badges.base.url"), "https://test.reevoo.com");
     }
 
     @Test

--- a/taglib/src/test/resources/reevooTaglibConfig.properties
+++ b/taglib/src/test/resources/reevooTaglibConfig.properties
@@ -1,5 +1,5 @@
-reevoo.badges.base.url=//test.reevoo.com
-reevoo.css.url=//mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css
-product.reviews.url=http://mark.reevoo.com/reevoomark/embeddable_reviews
-customer.experience.reviews.url=http://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews
-conversations.url=http://mark.reevoo.com/reevoomark/embeddable_conversations
+reevoo.badges.base.url=https://test.reevoo.com
+reevoo.css.url=https://mark.reevoo.com/stylesheets/reevoomark/embedded_reviews.css
+product.reviews.url=https://mark.reevoo.com/reevoomark/embeddable_reviews
+customer.experience.reviews.url=https://mark.reevoo.com/reevoomark/embeddable_customer_experience_reviews
+conversations.url=https://mark.reevoo.com/reevoomark/embeddable_conversations


### PR DESCRIPTION
This PR fixes two different tickets: [PROD-2652](https://reevoo.atlassian.net/browse/PROD-2652) and [PROD-2663](https://reevoo.atlassian.net/browse/PROD-2663).

It just adds `https` in front of each of the links that we are using to load resources from mark. It does something similar to https://github.com/reevoo/mark/pull/608 but in this case it's for embedded reviews, because the AJAX request didn't work in an https environment.
